### PR TITLE
Amend dependency versioning conflicts with bevy

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,7 @@ gltf = { version = "^1.0.0", default-features = false, features = [
 thiserror = "1.0"
 anyhow = "^1.0.70"
 base64 = "0.13.0"
-percent-encoding = "2.3"
+percent-encoding = "^2.1"
 
 [dev-dependencies]
 bevy = { version = "0.11", default-features = false, features = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ bevy = { version = "0.11", default-features = false, features = [
     "bevy_render",
     "bevy_scene",
 ] }
-gltf = { version = "1.2.0", default-features = false, features = [
+gltf = { version = "^1.0.0", default-features = false, features = [
     "KHR_lights_punctual",
     "KHR_materials_unlit",
     "extras",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,7 +25,7 @@ gltf = { version = "^1.0.0", default-features = false, features = [
     "utils",
 ] }
 thiserror = "1.0"
-anyhow = "1.0.71"
+anyhow = "^1.0.70"
 base64 = "0.13.0"
 percent-encoding = "2.3"
 


### PR DESCRIPTION
when I tried to compile your fix, I got version conflicts for `gltf`, `anyhow`, and `percent-encoding`. this should work.